### PR TITLE
Temporarily remove checks for Gliner setup

### DIFF
--- a/admin/src/routes/settings/Setup.tsx
+++ b/admin/src/routes/settings/Setup.tsx
@@ -1,5 +1,4 @@
 import { Component } from "solid-js";
-import Gliner from "../../widgets/settings/Gliner";
 import Ollama from "../../widgets/settings/Ollama";
 import Markdown from "../../widgets/typography/Markdown";
 import StorageDir from "../../widgets/settings/StorageDir";
@@ -25,9 +24,6 @@ const Setup: Component = () => {
 
           {!!workspace.settings?.pathToStorageDir ? (
             <>
-              <div class="mb-16" />
-              <Gliner />
-
               <div class="mb-16" />
               <Ollama />
 

--- a/admin/src/widgets/settings/StorageDir.tsx
+++ b/admin/src/widgets/settings/StorageDir.tsx
@@ -9,7 +9,7 @@ import { IFormFieldValue } from "../../utils/types";
 
 const help = `
 The storage directory is where we store the graph data, some AI/ML model data, etc.
-[Gliner](https://github.com/gliner/gliner), which is one of the AI/ML tools, needs about 6 GB of space.
+<!--[Gliner](https://github.com/gliner/gliner), which is one of the AI/ML tools, needs about 6 GB of space.-->
 
 Please copy and paste the path to the directory where you want to store the data.
 `;

--- a/pixlie_ai/src/config/mod.rs
+++ b/pixlie_ai/src/config/mod.rs
@@ -194,8 +194,6 @@ impl Settings {
                 incomplete_reasons.push(SettingsIncompleteReason::PythonVenvNotAvailable);
             } else if !python_status.pip {
                 incomplete_reasons.push(SettingsIncompleteReason::PythonPipNotAvailable);
-            } else if !get_is_gliner_setup()? {
-                incomplete_reasons.push(SettingsIncompleteReason::GlinerNotSetup);
             }
         }
         if self.anthropic_api_key.is_none() && self.ollama_hosts.is_none() {


### PR DESCRIPTION
- Remove Gliner setup check from settings status backend API
- Remove mentions of Gliner's setup from front-end Settings UI
  - Leave/comment out the component and other content references. They can be removed at the time of eventual Gliner integration