### PR TITLE
Refactor loading and validation of project engines

### DIFF
--- a/pixlie_ai/src/bin/pixlie.rs
+++ b/pixlie_ai/src/bin/pixlie.rs
@@ -254,7 +254,6 @@ fn main() {
                         continue;
                     }
                 };
-                // let project = Project::from_id(&project_id, path_to_storage_dir.clone());
                 let engine_project = ProjectForEngine::open(&project_id, path_to_storage_dir);
                 let (response_if_invalid_project_or_error, should_unload_engine) = match (
                     ProjectCollection::read_item(&project_id),

--- a/pixlie_ai/src/config/mod.rs
+++ b/pixlie_ai/src/config/mod.rs
@@ -104,6 +104,8 @@ pub fn check_cli_settings() -> PiResult<()> {
     Ok(())
 }
 
+// TODO: Move and refactor this logic to impl Settings::new,
+// eliminate the need for get_cli_settings_path
 pub fn get_cli_settings_path() -> PiResult<(PathBuf, PathBuf)> {
     let mut path_to_config_dir = config_dir().unwrap();
     path_to_config_dir.push("pixlie_ai");
@@ -117,6 +119,8 @@ pub fn get_cli_settings_path() -> PiResult<(PathBuf, PathBuf)> {
     Ok((path_to_config_dir, path_to_config_file))
 }
 
+// TODO: Move this function to impl Settings, eliminate the need for
+// get_cli_settings_path
 pub fn download_admin_site() -> PiResult<()> {
     // We download admin.tar.gz from our GitHub release
     let static_admin_dir = get_static_admin_dir()?;
@@ -179,6 +183,8 @@ pub fn download_admin_site() -> PiResult<()> {
     Ok(())
 }
 
+// TODO: Move this function to impl Settings, eliminate the need for
+// get_cli_settings_path
 pub fn get_static_admin_dir() -> PiResult<PathBuf> {
     let (path_to_config_dir, _path_to_config_file) = get_cli_settings_path()?;
     let mut static_root = PathBuf::from(path_to_config_dir.clone());

--- a/pixlie_ai/src/engine/engine.rs
+++ b/pixlie_ai/src/engine/engine.rs
@@ -6,6 +6,7 @@
 // https://github.com/pixlie/PixlieAI/blob/main/LICENSE
 
 use super::{EdgeLabel, NodeEdges, NodeFlags};
+use crate::config::Settings;
 use crate::engine::api::{handle_engine_api_request, EngineResponse, EngineResponsePayload};
 use crate::engine::edges::Edges;
 use crate::engine::node::{

--- a/pixlie_ai/src/engine/engine.rs
+++ b/pixlie_ai/src/engine/engine.rs
@@ -6,7 +6,6 @@
 // https://github.com/pixlie/PixlieAI/blob/main/LICENSE
 
 use super::{EdgeLabel, NodeEdges, NodeFlags};
-use crate::config::Settings;
 use crate::engine::api::{handle_engine_api_request, EngineResponse, EngineResponsePayload};
 use crate::engine::edges::Edges;
 use crate::engine::node::{

--- a/pixlie_ai/src/projects/api.rs
+++ b/pixlie_ai/src/projects/api.rs
@@ -31,7 +31,15 @@ pub async fn create_project(project: web::Json<ProjectCreate>) -> PiResult<impl 
         ),
         path_to_storage_dir,
     ) {
-        Ok(engine_project) => engine_project,
+        Ok(engine_project) => {
+            // TODO: Ideally this should be called in ProjectForEngine::new,
+            // but tests are failing if it is called there.
+            // We can move this call there once Settings is refactored to be
+            // cleanly testable and functions dependent on Settings are
+            // moved to impl Settings
+            ProjectCollection::create(engine_project.project.clone())?;
+            engine_project
+        }
         Err(err) => {
             return Err(PiError::InternalError(format!(
                 "Cannot create project: {}",

--- a/pixlie_ai/src/projects/api.rs
+++ b/pixlie_ai/src/projects/api.rs
@@ -31,10 +31,7 @@ pub async fn create_project(project: web::Json<ProjectCreate>) -> PiResult<impl 
         ),
         path_to_storage_dir,
     ) {
-        Ok(engine_project) => {
-            ProjectCollection::create(engine_project.project.clone())?;
-            engine_project
-        }
+        Ok(engine_project) => engine_project,
         Err(err) => {
             return Err(PiError::InternalError(format!(
                 "Cannot create project: {}",

--- a/pixlie_ai/src/projects/mod.rs
+++ b/pixlie_ai/src/projects/mod.rs
@@ -78,9 +78,8 @@ impl ProjectForEngine {
         project
     }
     pub fn get_db_path(&self) -> PathBuf {
-        let mut path_to_storage_dir = self.path_to_storage_dir.clone();
-        path_to_storage_dir.push(format!("{}.rocksdb", self.project.uuid));
-        path_to_storage_dir
+        self.path_to_storage_dir
+            .join(format!("{}.rocksdb", self.project.uuid))
     }
     pub fn get_arced_db(&self) -> PiResult<Arc<DB>> {
         match self.arced_db.as_ref() {

--- a/pixlie_ai/src/projects/mod.rs
+++ b/pixlie_ai/src/projects/mod.rs
@@ -1,4 +1,10 @@
-use crate::utils::crud::{Crud, CrudItem};
+use std::{path::PathBuf, sync::Arc};
+
+use crate::{
+    error::{PiError, PiResult},
+    utils::crud::{Crud, CrudItem},
+};
+use rocksdb::DB;
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
@@ -36,6 +42,81 @@ impl Project {
             description,
             owner,
         }
+    }
+    pub fn from_id(uuid: &str) -> Project {
+        Project {
+            uuid: uuid.to_string(),
+            name: None,
+            description: None,
+            owner: ProjectOwner::Myself,
+        }
+    }
+}
+
+pub struct ProjectForEngine {
+    pub project: Project,
+    pub path_to_storage_dir: PathBuf,
+    pub arced_db: Option<Arc<DB>>,
+}
+
+impl ProjectForEngine {
+    pub fn new(project: Project, path_to_storage_dir: PathBuf) -> PiResult<Self> {
+        let mut project = Self {
+            project,
+            path_to_storage_dir,
+            arced_db: None,
+        };
+        project.init_db()?;
+        Ok(project)
+    }
+    pub fn open(uuid: &str, path_to_storage_dir: PathBuf) -> Self {
+        let project = Self {
+            project: Project::from_id(uuid),
+            path_to_storage_dir,
+            arced_db: None,
+        };
+        project
+    }
+    pub fn get_db_path(&self) -> PathBuf {
+        let mut path_to_storage_dir = self.path_to_storage_dir.clone();
+        path_to_storage_dir.push(format!("{}.rocksdb", self.project.uuid));
+        path_to_storage_dir
+    }
+    pub fn get_arced_db(&self) -> PiResult<Arc<DB>> {
+        match self.arced_db.as_ref() {
+            Some(db) => Ok(db.clone()),
+            None => Err(PiError::InternalError(
+                "Cannot get DB: DB is not open".to_string(),
+            )),
+        }
+    }
+    fn init_db(&mut self) -> PiResult<()> {
+        let db_path = self.get_db_path();
+        match DB::open_default(db_path.as_os_str()) {
+            Ok(_) => Ok(()),
+            Err(error) => Err(PiError::InternalError(format!(
+                "Cannot open DB for project: {}",
+                error
+            ))),
+        }
+    }
+    pub fn load_db(&mut self) -> PiResult<()> {
+        let db_path = self.get_db_path();
+        if db_path.exists() && db_path.is_dir() {
+            let mut opts = rocksdb::Options::default();
+            opts.create_if_missing(false);
+            let db = DB::open(&opts, db_path.as_os_str())?;
+            self.arced_db = Some(Arc::new(db));
+            Ok(())
+        } else {
+            Err(PiError::InternalError(format!(
+                "DB does not exist at path: {}",
+                db_path.display()
+            )))
+        }
+    }
+    pub fn db_exists(&self) -> bool {
+        self.get_db_path().exists()
     }
 }
 

--- a/pixlie_ai/src/projects/mod.rs
+++ b/pixlie_ai/src/projects/mod.rs
@@ -73,7 +73,12 @@ impl ProjectForEngine {
             arced_db: None,
         };
         project.init_db()?;
-        ProjectCollection::create(project.project.clone())?;
+        // TODO: Ideally this should be called here, but tests are failing
+        // if it is called here.
+        // We can move this call here once Settings is refactored to be
+        // cleanly testable and functions dependent on Settings are
+        // moved to impl Settings
+        // ProjectCollection::create(project.project.clone())?;
         Ok(project)
     }
     pub fn open(uuid: &str, path_to_storage_dir: PathBuf) -> Self {


### PR DESCRIPTION
This refactors how project engines are loaded and validated, centralizing project validation logic before loading engines. It introduces `ProjectForEngine`, improves error handling for non-existent projects, and separates database initialization from data loading.