### PR TITLE
Add OpenAPI documentation improvements

### DIFF
--- a/pixlie_ai/Cargo.lock
+++ b/pixlie_ai/Cargo.lock
@@ -70,10 +70,12 @@ dependencies = [
  "actix-utils",
  "base64",
  "bitflags",
+ "brotli",
  "bytes",
  "bytestring",
  "derive_more 2.0.1",
  "encoding_rs",
+ "flate2",
  "foldhash",
  "futures-core",
  "h2",
@@ -92,6 +94,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "zstd",
 ]
 
 [[package]]
@@ -113,6 +116,7 @@ dependencies = [
  "bytestring",
  "cfg-if",
  "http 0.2.12",
+ "regex",
  "regex-lite",
  "serde",
  "tracing",
@@ -203,6 +207,7 @@ dependencies = [
  "bytes",
  "bytestring",
  "cfg-if",
+ "cookie",
  "derive_more 2.0.1",
  "encoding_rs",
  "foldhash",
@@ -215,6 +220,7 @@ dependencies = [
  "mime",
  "once_cell",
  "pin-project-lite",
+ "regex",
  "regex-lite",
  "serde",
  "serde_json",
@@ -273,6 +279,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -447,6 +468,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +626,17 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "cookie"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
 
 [[package]]
 name = "core-foundation"
@@ -2020,6 +2073,8 @@ dependencies = [
  "url",
  "utoipa",
  "utoipa-actix-web",
+ "utoipa-rapidoc",
+ "utoipa-redoc",
  "utoipa-swagger-ui",
  "uuid",
 ]
@@ -3301,6 +3356,32 @@ dependencies = [
  "quote",
  "regex",
  "syn",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "utoipa-rapidoc"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5f8f5abd341cce16bb4f09a8bafc087d4884a004f25fb980e538d51d6501dab"
+dependencies = [
+ "actix-web",
+ "serde",
+ "serde_json",
+ "utoipa",
+]
+
+[[package]]
+name = "utoipa-redoc"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6427547f6db7ec006cbbef95f7565952a16f362e298b416d2d497d9706fef72d"
+dependencies = [
+ "actix-web",
+ "serde",
+ "serde_json",
+ "utoipa",
 ]
 
 [[package]]
@@ -3953,4 +4034,32 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/pixlie_ai/Cargo.toml
+++ b/pixlie_ai/Cargo.toml
@@ -49,9 +49,11 @@ url = { version = "2.5.3", default-features = false }
 uuid = { version = "1.12.0", default-features = false, features = ["v4"] }
 tempfile = "3.17.1"
 bitflags = { version = "2.9.0", default-features = false, features = ["serde"] }
-utoipa = { version = "5.3.1", features = ["actix_extras"] }
+utoipa = { version = "5.3.1", features = ["actix_extras", "chrono", "non_strict_integers", "url", "uuid"] }
 utoipa-swagger-ui = { version = "9.0.1", features = ["actix-web"] }
 utoipa-actix-web = "0.1.2"
+utoipa-redoc = { version = "6.0.0", features = ["actix-web"] }
+utoipa-rapidoc = { version = "6.0.0", features = ["actix-web"] }
 
 # https://github.com/johnthagen/min-sized-rust
 [profile.release]

--- a/pixlie_ai/src/api/mod.rs
+++ b/pixlie_ai/src/api/mod.rs
@@ -21,12 +21,15 @@ use log::{debug, error, info};
 use rustls::pki_types::PrivateKeyDer;
 use rustls::ServerConfig;
 use rustls_pemfile::{certs, pkcs8_private_keys};
+use serde_json::json;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
 use utoipa::OpenApi;
 use utoipa_actix_web::AppExt;
-use utoipa_swagger_ui::SwaggerUi;
+use utoipa_rapidoc::RapiDoc;
+use utoipa_redoc::{Redoc, Servable};
+use utoipa_swagger_ui::{Config, SwaggerUi};
 
 const API_ROOT: &str = "/api";
 
@@ -209,11 +212,28 @@ pub fn api_manager(
                                 .openapi_service(|api| {
                                     SwaggerUi::new("/swagger/{_:.*}")
                                         .url("/api-docs/openapi.json", api)
+                                        .config(
+                                            Config::default()
+                                                .with_syntax_highlight(false)
+                                                .query_config_enabled(true),
+                                        )
                                 })
                                 .map(|app| app.wrap(cors).wrap(Logger::new("%r: %s %b %T")))
                                 .app_data(api_state.clone())
                                 .configure(configure_app)
                                 .into_app()
+                                .service(Redoc::with_url_and_config(
+                                    "/redoc",
+                                    ApiDoc::openapi(),
+                                    || json!({}),
+                                ))
+                                .service(
+                                    RapiDoc::with_openapi(
+                                        "/api-docs/openapi.json",
+                                        ApiDoc::openapi(),
+                                    )
+                                    .path("/rapidoc"),
+                                )
                                 .configure(configure_static_admin)
                         })
                         .bind_rustls_0_23((with_hostname.hostname.clone(), 58236), host_config)?
@@ -249,12 +269,30 @@ pub fn api_manager(
                         .into_utoipa_app()
                         .openapi(ApiDoc::openapi())
                         .openapi_service(|api| {
-                            SwaggerUi::new("/swagger/{_:.*}").url("/api-docs/openapi.json", api)
+                            SwaggerUi::new("/swagger/{_:.*}")
+                                .url("/api-docs/openapi.json", api)
+                                .config(
+                                    Config::default()
+                                        .with_syntax_highlight(false)
+                                        .query_config_enabled(true),
+                                )
                         })
                         .map(|app| app.wrap(cors).wrap(Logger::new("%r: %s %b %T")))
                         .app_data(api_state.clone())
                         .configure(configure_app)
                         .into_app()
+                        .service(Redoc::with_url_and_config(
+                            "/redoc",
+                            ApiDoc::openapi(),
+                            || json!({}),
+                        ))
+                        .service(
+                            utoipa_rapidoc::RapiDoc::with_openapi(
+                                "/api-docs/openapi.json",
+                                ApiDoc::openapi(),
+                            )
+                            .path("/rapidoc"),
+                        )
                         .configure(configure_static_admin)
                 })
                 .bind(("localhost", 58236))?

--- a/pixlie_ai/src/engine/api.rs
+++ b/pixlie_ai/src/engine/api.rs
@@ -36,6 +36,8 @@ pub struct EngineRequest {
 #[derive(Clone, Deserialize, ToSchema, TS)]
 #[ts(export)]
 pub struct LinkWrite {
+    /// The URL of the link
+    #[schema(value_type = url::Url)]
     pub url: String,
 }
 
@@ -84,6 +86,8 @@ pub enum EngineRequestPayload {
 #[derive(Clone, Serialize, ToSchema, TS)]
 #[ts(export)]
 pub struct APINodeEdges {
+    // TODO: The edges should be Vec<(NodeId, EdgeLabel)>
+    // Change this and handle chain-effects, if any
     #[ts(type = "Array<[number, string]>")]
     pub edges: Vec<(NodeId, String)>,
     pub written_at: i64,
@@ -109,6 +113,9 @@ pub enum EngineResponsePayload {
     EdgeCreatedSuccessfully,
     /// Response for node query. Returns a list of nodes.
     Nodes(Vec<APINodeItem>),
+
+    // TODO: The below should be Labels(Vec<NodeLabel>)
+    // Change this and handle chain-effects, if any
     /// Response for label retrieval. Returns a list of labels.
     Labels(Vec<String>),
     /// Response for edge retrieval. Returns a list of edges.
@@ -229,6 +236,8 @@ pub struct EngineResponse {
 
 #[derive(Deserialize, IntoParams)]
 pub struct QueryNodes {
+    // TODO: The below should be Option<NodeLabel>
+    // Change this and handle chain-effects, if any
     /// The node label to filter nodes by.
     /// If provided, ids & since will be ignored.
     label: Option<String>,
@@ -260,8 +269,8 @@ pub struct QueryEdges {
     ),
     params(
         (
-            "project_id",
-            description = "The ID of the project (UUID)",
+            "project_id" = uuid::Uuid,
+            description = "The ID of the project",
             example = "123e4567-e89b-12d3-a456-426614174000"
         ),
     ),
@@ -329,8 +338,8 @@ pub async fn get_labels(
     ),
     params(
         (
-            "project_id",
-            description = "The ID of the project (UUID)",
+            "project_id" = uuid::Uuid,
+            description = "The ID of the project",
             example = "123e4567-e89b-12d3-a456-426614174000"
         ),
         QueryNodes,
@@ -446,8 +455,8 @@ pub async fn get_nodes(
     ),
     params(
         (
-            "project_id",
-            description = "The ID of the project (UUID)",
+            "project_id" = uuid::Uuid,
+            description = "The ID of the project",
             example = "123e4567-e89b-12d3-a456-426614174000"
         ),
         QueryEdges,
@@ -523,8 +532,8 @@ pub async fn get_edges(
     ),
     params(
         (
-            "project_id",
-            description = "The ID of the project (UUID)",
+            "project_id" = uuid::Uuid,
+            description = "The ID of the project",
             example = "123e4567-e89b-12d3-a456-426614174000"
         ),
     ),
@@ -596,8 +605,8 @@ pub async fn create_node(
     ),
     params(
         (
-            "project_id",
-            description = "The ID of the project (UUID)",
+            "project_id" = uuid::Uuid,
+            description = "The ID of the project",
             example = "123e4567-e89b-12d3-a456-426614174000"
         ),
     ),
@@ -673,12 +682,12 @@ pub async fn create_edge(
     ),
     params(
         (
-            "project_id",
+            "project_id" = uuid::Uuid,
             description = "The ID of the project",
             example = "123e4567-e89b-12d3-a456-426614174000"
         ),
         (
-            "node_id",
+            "node_id" = NodeId,
             description = "The ID of the node to query",
             example = 123
         ),

--- a/pixlie_ai/src/entity/content.rs
+++ b/pixlie_ai/src/entity/content.rs
@@ -5,15 +5,10 @@
 //
 // https://github.com/pixlie/PixlieAI/blob/main/LICENSE
 
-use std::borrow::Cow;
-
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
-use utoipa::{
-    openapi::{schema::SchemaType, ObjectBuilder, Schema, SchemaFormat, Type},
-    PartialSchema, ToSchema,
-};
+use utoipa::ToSchema;
 
 #[derive(Clone, Deserialize, Serialize, ToSchema, TS)]
 #[ts(export)]
@@ -28,33 +23,6 @@ pub struct LossyLocation {
     pub country: String,
 }
 
-// https://github.com/juhaku/utoipa/issues/1057
-#[derive(Clone, Debug, Serialize, Deserialize, TS)]
-pub struct DateTimeWrapper(pub DateTime<Utc>);
-
-impl PartialSchema for DateTimeWrapper {
-    fn schema() -> utoipa::openapi::RefOr<Schema> {
-        utoipa::openapi::RefOr::T(Schema::Object(
-            ObjectBuilder::new()
-                .schema_type(SchemaType::Type(Type::String))
-                .format(Some(SchemaFormat::KnownFormat(
-                    utoipa::openapi::KnownFormat::Time,
-                )))
-                .build(),
-        ))
-    }
-}
-
-impl ToSchema for DateTimeWrapper {
-    fn name() -> Cow<'static, str> {
-        Cow::Borrowed("DateTimeWrapper")
-    }
-
-    fn schemas(_schemas: &mut Vec<(String, utoipa::openapi::RefOr<Schema>)>) {
-        // No nested types to register
-    }
-}
-
 #[derive(Clone, Deserialize, Serialize, ToSchema, TS)]
 #[ts(export)]
 pub enum TypedData {
@@ -63,9 +31,9 @@ pub enum TypedData {
     Float(f32),
     String(String),
     Boolean(bool),
-    Date(DateTimeWrapper),
-    Time(DateTimeWrapper),
-    DateTime(DateTimeWrapper),
+    Date(DateTime<Utc>),
+    Time(DateTime<Utc>),
+    DateTime(DateTime<Utc>),
     Email(String),
     Link(String),
     Currency(String),

--- a/pixlie_ai/src/projects/mod.rs
+++ b/pixlie_ai/src/projects/mod.rs
@@ -23,9 +23,13 @@ pub enum ProjectOwner {
 #[derive(Clone, Deserialize, Serialize, ToSchema, TS)]
 #[ts(export)]
 pub struct Project {
+    /// Project ID (UUID)
     pub uuid: String,
+    /// Project name - this is assigned by AI
     pub name: Option<String>,
+    /// Project description - currently unused
     pub description: Option<String>,
+    /// Project owner - for future use, currently defaults to Myself
     pub owner: ProjectOwner,
 }
 


### PR DESCRIPTION
Further changes for #166

- Add RedDoc and RapiDoc alternatives to SwaggerUI to see which one works better. We can trim these down later as they bloat build size.
- Enhance schema documentation with better type information.
- Add UUID, URL & wider integer-variation type annotations in API schemas, by enabling corresponding features for utoipa.
- Switch off syntax highlighting for SwaggerUI for reduced browser CPU usage for large responses.
    - https://github.com/swagger-api/swagger-ui/issues/3832
- Remove custom DateTimeWrapper in favor of native DateTime support by enabling the chrono feature for utoipa
- Include TODOs for some future Pixlie AI type changes.