### PR TITLE
Increase timeout for crawler's fetches to 30s

### DIFF
--- a/pixlie_ai/src/utils/fetcher.rs
+++ b/pixlie_ai/src/utils/fetcher.rs
@@ -95,7 +95,7 @@ async fn fetch(request: InternalFetchRequest) -> FetchResult {
     let client = match Client::builder()
         .user_agent("Pixlie AI bot (https://pixlie.com)")
         .timeout(Duration::from_secs(match request.crawl_or_api_request {
-            CrawlOrAPIRequest::Crawl(_) => 5,
+            CrawlOrAPIRequest::Crawl(_) => 30,
             CrawlOrAPIRequest::API(_) => 60,
         }))
         .build()


### PR DESCRIPTION
This resolves the problem for not being able to fetch mmediu.ro for #181