### PR TITLE
Fix issues pertaining to domain-limited crawls

### DIFF
--- a/pixlie_ai/src/entity/search/web_search.rs
+++ b/pixlie_ai/src/entity/search/web_search.rs
@@ -38,7 +38,7 @@ impl WebSearch {
                                 }
                             };
                         // Skip if project settings are not available
-                        let project_settings = match engine
+                        let (project_settings_node_id, project_settings) = match engine
                             .get_node_ids_with_label(&NodeLabel::ProjectSettings)
                         {
                             settings_node_ids => {
@@ -47,7 +47,8 @@ impl WebSearch {
                                         "No ProjectSettings node found".to_string(),
                                     ));
                                 }
-                                match engine.get_node_by_id(&settings_node_ids[0]) {
+                                let settings_node_id = *settings_node_ids[0];
+                                match engine.get_node_by_id(&settings_node_id) {
                                     Some(settings_node) => {
                                         if settings_node
                                             .labels
@@ -55,7 +56,7 @@ impl WebSearch {
                                         {
                                             match &settings_node.payload {
                                                 Payload::ProjectSettings(settings) => {
-                                                    settings.clone()
+                                                    (settings_node_id, settings.clone())
                                                 }
                                                 _ => {
                                                     return Err(PiError::GraphError(
@@ -88,8 +89,8 @@ impl WebSearch {
                                 None => continue,
                             };
                             if project_settings.is_domain_allowed(
-                                &node.id,
-                                domain,
+                                &project_settings_node_id,
+                                domain.to_string(),
                                 engine.clone(),
                             )? {
                                 let link_node_id = Link::add(

--- a/pixlie_ai/src/entity/web/link.rs
+++ b/pixlie_ai/src/entity/web/link.rs
@@ -241,7 +241,11 @@ impl Link {
                     )?;
                     engine.toggle_flag(&node.id, NodeFlags::IS_PROCESSED)?;
                 }
-                ExternalData::Error(_error) => {
+                ExternalData::Error(error) => {
+                    error!(
+                        "Error processing link {}({}): {}. The link will be attempted again later.",
+                        &url, node.id, error.error
+                    );
                     engine.toggle_flag(&node.id, NodeFlags::HAD_ERROR)?;
                 }
             },


### PR DESCRIPTION
- Implement dependency checking system for node processing
- Only process WebPage and WebSearch nodes, if processing of Objective is complete.
- Correct domain check bug for web searches
- Add logs for node processing errors